### PR TITLE
BUG FIX: Package requires 'data.tree' in order to be installed + more

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,6 @@ Version: 0.78-9000
 Title: Machine Learning and Visualization
 Date: 2019-04-01
 Authors@R: person(given = "Efstathios D.", family = "Gennatas", role = c("aut", "cre"), email = "gennatas@gmail.com", comment = c(ORCID = "0000-0001-9280-3609"))
-Author: Efstathios D Gennatas [aut, cre]
 Maintainer: Efstathios D. Gennatas <gennatas@gmail.com>
 Description: Advanced Machine Learning and Visualization made accessible to all. Unsupervised Learning (Clustering, Decomposition), Supervised Learning (Classification, Regression, Survival Analysis), Cross-Decomposition, Bagging, Boosting, Meta-models.
 License: GPL (>=3)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,4 +11,3 @@ ByteCompile: yes
 Imports: grDevices, graphics, stats, utils, parallel, future, magrittr, methods, data.table, crayon, data.tree
 Suggests: ada, ANTsR, arm, bartMachine, base64enc, caret, cluster, C50, deepnet, dendextend (>= 0.18.0), doParallel, d3heatmap, earth, EMCluster, extraTrees, evtree, e1071, fastICA, flexclust, FNN, foreach, fpc, gamsel, gbm, gbm3, ggplot2, glmnet, GPArotation, grid, gsubfn, heatmaply, hopach, htmlwidgets, h2o, ica, imager, inTrees, iRF, keras, kernlab, lars, lavaan, leaps, lightgbm, lle, MASS, mda, mgcv, missForest, mxnet, nlme, nnet, NMF, np, nsprcomp, oro.nifti, partykit, pbapply, plotly, polspline, PPtree, pROC, psych, PMA, png, plyr, pvclust, qrnn, randomForest, randomForestSRC, ranger, rCUR, RColorBrewer, RNifti, ROCR, rpart, rpart.plot, rstudioapi, Rtsne, R6, R.utils, scales (>= 0.2.5), sgd, snow, snowfall, sparklyr, splines2, spls, survival, tgp, vegan, xgboost, knitr, rmarkdown, uwot
 RoxygenNote: 6.1.1
-VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rtemis
-Version: 0.78
+Version: 0.78-9000
 Title: Machine Learning and Visualization
 Date: 2019-04-01
 Authors@R: person(given = "Efstathios D.", family = "Gennatas", role = c("aut", "cre"), email = "gennatas@gmail.com", comment = c(ORCID = "0000-0001-9280-3609"))
@@ -9,7 +9,7 @@ Description: Advanced Machine Learning and Visualization made accessible to all.
 License: GPL (>=3)
 URL: rtemis.netlify.com
 ByteCompile: yes
-Imports: grDevices, graphics, stats, utils, parallel, future, magrittr, methods, data.table, crayon
-Suggests: ada, ANTsR, arm, bartMachine, base64enc, caret, cluster, C50, data.tree, deepnet, dendextend (>= 0.18.0), doParallel, d3heatmap, earth, EMCluster, extraTrees, evtree, e1071, fastICA, flexclust, FNN, foreach, fpc, gamsel, gbm, gbm3, ggplot2, glmnet, GPArotation, grid, gsubfn, heatmaply, hopach, htmlwidgets, h2o, ica, imager, inTrees, iRF, keras, kernlab, lars, lavaan, leaps, lightgbm, lle, MASS, mda, mgcv, missForest, mxnet, nlme, nnet, NMF, np, nsprcomp, oro.nifti, partykit, pbapply, plotly, polspline, PPtree, pROC, psych, PMA, png, plyr, pvclust, qrnn, randomForest, randomForestSRC, ranger, rCUR, RColorBrewer, RNifti, ROCR, rpart, rpart.plot, rstudioapi, Rtsne, R6, R.utils, scales (>= 0.2.5), sgd, snow, snowfall, sparklyr, splines2, spls, survival, tgp, vegan, xgboost, knitr, rmarkdown, uwot
+Imports: grDevices, graphics, stats, utils, parallel, future, magrittr, methods, data.table, crayon, data.tree
+Suggests: ada, ANTsR, arm, bartMachine, base64enc, caret, cluster, C50, deepnet, dendextend (>= 0.18.0), doParallel, d3heatmap, earth, EMCluster, extraTrees, evtree, e1071, fastICA, flexclust, FNN, foreach, fpc, gamsel, gbm, gbm3, ggplot2, glmnet, GPArotation, grid, gsubfn, heatmaply, hopach, htmlwidgets, h2o, ica, imager, inTrees, iRF, keras, kernlab, lars, lavaan, leaps, lightgbm, lle, MASS, mda, mgcv, missForest, mxnet, nlme, nnet, NMF, np, nsprcomp, oro.nifti, partykit, pbapply, plotly, polspline, PPtree, pROC, psych, PMA, png, plyr, pvclust, qrnn, randomForest, randomForestSRC, ranger, rCUR, RColorBrewer, RNifti, ROCR, rpart, rpart.plot, rstudioapi, Rtsne, R6, R.utils, scales (>= 0.2.5), sgd, snow, snowfall, sparklyr, splines2, spls, survival, tgp, vegan, xgboost, knitr, rmarkdown, uwot
 RoxygenNote: 6.1.1
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Author: Efstathios D Gennatas [aut, cre]
 Maintainer: Efstathios D. Gennatas <gennatas@gmail.com>
 Description: Advanced Machine Learning and Visualization made accessible to all. Unsupervised Learning (Clustering, Decomposition), Supervised Learning (Classification, Regression, Survival Analysis), Cross-Decomposition, Bagging, Boosting, Meta-models.
 License: GPL (>=3)
-URL: rtemis.netlify.com
+URL: https://rtemis.netlify.com
 ByteCompile: yes
 Imports: grDevices, graphics, stats, utils, parallel, future, magrittr, methods, data.table, crayon, data.tree
 Suggests: ada, ANTsR, arm, bartMachine, base64enc, caret, cluster, C50, deepnet, dendextend (>= 0.18.0), doParallel, d3heatmap, earth, EMCluster, extraTrees, evtree, e1071, fastICA, flexclust, FNN, foreach, fpc, gamsel, gbm, gbm3, ggplot2, glmnet, GPArotation, grid, gsubfn, heatmaply, hopach, htmlwidgets, h2o, ica, imager, inTrees, iRF, keras, kernlab, lars, lavaan, leaps, lightgbm, lle, MASS, mda, mgcv, missForest, mxnet, nlme, nnet, NMF, np, nsprcomp, oro.nifti, partykit, pbapply, plotly, polspline, PPtree, pROC, psych, PMA, png, plyr, pvclust, qrnn, randomForest, randomForestSRC, ranger, rCUR, RColorBrewer, RNifti, ROCR, rpart, rpart.plot, rstudioapi, Rtsne, R6, R.utils, scales (>= 0.2.5), sgd, snow, snowfall, sparklyr, splines2, spls, survival, tgp, vegan, xgboost, knitr, rmarkdown, uwot


### PR DESCRIPTION
The following line:

https://github.com/egenn/rtemis/blob/d8637cc5c3056d988c8563ebca7795ec6780644a/R/zzz.R#L55

makes the dependency on data.tree mandatory.  This PR addresses that and should make:
```r
remotes::install_github("egenn/rtemis")
```
install everything in a fresh R installation.
