### PR TITLE
Fix R CMD check NOTEs

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,3 @@
+.*~
+.travis.yml
+LICENSE.txt

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ vignettes/*.pdf
 *.utf8.md
 *.knit.md
 inst/doc
+# Temporary files created editors
+*~


### PR DESCRIPTION
Add .Rbuildignore:
* Avoid adding .travis.yml to R package
* R packages don't need a LICENSE file for known FOSS licenses